### PR TITLE
add regexp validation to user properties

### DIFF
--- a/Java/spring-thymeleaf-crud-example/src/main/java/com/example/thymeleaf/dto/CreateStudentDTO.java
+++ b/Java/spring-thymeleaf-crud-example/src/main/java/com/example/thymeleaf/dto/CreateStudentDTO.java
@@ -7,6 +7,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.time.LocalDate;
 
 @Getter
@@ -14,6 +15,7 @@ import java.time.LocalDate;
 public class CreateStudentDTO {
 
     @NotEmpty(message = "{NotEmpty.name}")
+    @Pattern(regexp = "^[\\p{L} .'-]+$", message = "{Pattern.name}")
     private String name;
 
     @Email
@@ -25,23 +27,30 @@ public class CreateStudentDTO {
     private LocalDate birthday;
 
     @NotEmpty(message = "{NotEmpty.zipCode}")
+    @Pattern(regexp = "^[0-9-]+$", message = "{Pattern.zipCode}")
     private String zipCode;
 
     @NotEmpty(message = "{NotEmpty.street}")
+    @Pattern(regexp = "^[\\p{L}0-9 .'-]+$", message = "{Pattern.street}")
     private String street;
 
     @NotEmpty(message = "{NotEmpty.number}")
+    @Pattern(regexp = "^[\\p{L}0-9]+$", message = "{Pattern.number}")
     private String number;
 
+    @Pattern(regexp = "^[\\p{L}0-9 .'-]*$", message = "{Pattern.complement}")
     private String complement;
 
     @NotEmpty(message = "{NotEmpty.district}")
+    @Pattern(regexp = "^[\\p{L} .'-]+$", message = "{Pattern.district}")
     private String district;
 
     @NotEmpty(message = "{NotEmpty.city}")
+    @Pattern(regexp = "^[\\p{L} .'-]+$", message = "{Pattern.city}")
     private String city;
 
     @NotEmpty(message = "{NotEmpty.state}")
+    @Pattern(regexp = "^[\\p{L} .'-]+$", message = "{Pattern.state}")
     private String state;
 
 }


### PR DESCRIPTION
Pola podatne na XSS: name, street, district, city, state. Można umieścić w formularzu przykładowo:
<script>alert('XSS')</script>

Zamiast danych w odpowiednim miejscu pokazuje się alert

<img width="1255" alt="Screenshot 2024-11-12 at 17 23 49" src="https://github.com/user-attachments/assets/8714abbc-e79d-4992-9b4f-3da56850b7cc">
